### PR TITLE
If message is Symbol, Exception occurred.

### DIFF
--- a/lib/act-fluent-logger-rails/logger.rb
+++ b/lib/act-fluent-logger-rails/logger.rb
@@ -84,7 +84,7 @@ module ActFluentLoggerRails
       if message.encoding == Encoding::UTF_8
         @messages << message
       else
-        @messages << message.dup.force_encoding(Encoding::UTF_8)
+        @messages << message.to_s.dup.force_encoding(Encoding::UTF_8)
       end
     end
 


### PR DESCRIPTION
In "add_message" line 87, Exception occurred if ARG "message" is Symbol.
Symbol cannot use "dup".